### PR TITLE
DM-49027 ATBuilding CSC needs to work with either DDS or Kafka

### DIFF
--- a/python/lsst/ts/atbuilding/csc/building_csc.py
+++ b/python/lsst/ts/atbuilding/csc/building_csc.py
@@ -133,14 +133,24 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         extraction_fan_payload = dict(driveFrequency=drive_frequency)
 
         # Check whether driveVoltage is part of the extractionFan telemetry.
-        if hasattr(self.salinfo, "metadata"):
-            topic_info = self.salinfo.metadata.topic_info["extractionFan"]
-            if "driveVoltage" in topic_info.field_info and drive_voltage is not None:
-                extraction_fan_payload["driveVoltage"] = drive_voltage
-        elif hasattr(self.salinfo, "component_info"):
-            fields = self.salinfo.component_info.topics["tel_extractionFan"].fields
+        try:
+            component_info = self.salinfo.component_info
+            fields = component_info.topics["tel_extractionFan"].fields
             if "driveVoltage" in fields.keys() and drive_voltage is not None:
                 extraction_fan_payload["driveVoltage"] = drive_voltage
+        except AttributeError:
+            try:
+                metadata = self.salinfo.metadata
+                topic_info = metadata.topic_info["extractionFan"]
+                if (
+                    "driveVoltage" in topic_info.field_info
+                    and drive_voltage is not None
+                ):
+                    extraction_fan_payload["driveVoltage"] = drive_voltage
+            except AttributeError:
+                raise RuntimeError(
+                    "Neither component_info nor metadata is available in salinfo."
+                )
 
         await self.tel_extractionFan.set_write(**extraction_fan_payload)
 

--- a/python/lsst/ts/atbuilding/csc/building_csc.py
+++ b/python/lsst/ts/atbuilding/csc/building_csc.py
@@ -130,12 +130,17 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         drive_frequency = message_json["data"]["tel_extraction_fan"]
         drive_voltage = message_json["data"].get("tel_drive_voltage", None)
 
-        # Check whether driveVoltage is part of the extractionFan telemetry.
-        topic_info = self.salinfo.metadata.topic_info["extractionFan"]
         extraction_fan_payload = dict(driveFrequency=drive_frequency)
 
-        if "driveVoltage" in topic_info.field_info and drive_voltage is not None:
-            extraction_fan_payload["driveVoltage"] = drive_voltage
+        # Check whether driveVoltage is part of the extractionFan telemetry.
+        if hasattr(self.salinfo, "metadata"):
+            topic_info = self.salinfo.metadata.topic_info["extractionFan"]
+            if "driveVoltage" in topic_info.field_info and drive_voltage is not None:
+                extraction_fan_payload["driveVoltage"] = drive_voltage
+        elif hasattr(self.salinfo, "component_info"):
+            fields = self.salinfo.component_info.topics["tel_extractionFan"].fields
+            if "driveVoltage" in fields.keys():
+                extraction_fan_payload["driveVoltage"] = drive_voltage
 
         await self.tel_extractionFan.set_write(**extraction_fan_payload)
 

--- a/python/lsst/ts/atbuilding/csc/building_csc.py
+++ b/python/lsst/ts/atbuilding/csc/building_csc.py
@@ -139,7 +139,7 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
                 extraction_fan_payload["driveVoltage"] = drive_voltage
         elif hasattr(self.salinfo, "component_info"):
             fields = self.salinfo.component_info.topics["tel_extractionFan"].fields
-            if "driveVoltage" in fields.keys():
+            if "driveVoltage" in fields.keys() and drive_voltage is not None:
                 extraction_fan_payload["driveVoltage"] = drive_voltage
 
         await self.tel_extractionFan.set_write(**extraction_fan_payload)


### PR DESCRIPTION
The ATBuilding CSC needs to use salinfo in a way that is compatible with both the DDS salobj (which uses salinfo.metadata) and the Kafka salobj (which uses salinfo.component_info). I ran into exactly this problem with the DIMM CSC and Wouter kindly showed me his solution to the problem.