### PR TITLE
DM-49469 Use handle_summary_state to connect/disconnect the CSC

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v0.2.1
+------
+
+* Reconfigured connect/disconnect to use `handle_summary_state`.
+
 v0.2.0
 ------
 


### PR DESCRIPTION
We ran into a problem tonight when trying to re-enable the ATBuilding CSC. The problem is incorrect handling of connect/disconnect in the CSC. This should solve the problem.