### PR TITLE
OSW-2112: Add reconnect retry handling for unexpected controller disconnects.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@ DevelopPipeline(
     name: "ts_atbuilding_csc",
     module_name: "lsst.ts.atbuilding.csc",
     idl_names: ["ATBuilding"],
-    extra_packages: ["lsst-ts/ts_atbuilding_vents"]
+    extra_packages: ["lsst-ts/ts_atbuilding_vents", "lsst-ts/ts_xml"]
 )

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,12 +1,35 @@
+# This file is part of ts_atbuilding_csc.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
-For more information, see:
-https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.conf.pipelinespkg import *
+import lsst.ts.atbuilding.csc  # noqa
+from documenteer.conf.guide import *  # noqa
 
 project = "ts_atbuilding_csc"
+html_theme_options["logotext"] = project  # type: ignore # noqa
 html_title = project
 html_short_title = project
+html_static_path = ["_static"]
+html_css_files = ["mystyle.css"]

--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -1,0 +1,18 @@
+[project]
+title = "ATBuilding CSC"
+# Copyright information displayed on the footer of each page
+copyright = "2019-2026 Association of Universities for Research in Astronomy, Inc. (AURA)"
+
+[project.python]
+# pyproject.toml package name, fills out unseen metadata
+package = "ts_atbuilding_csc"
+documentation_url_key = "documentation"
+github_url_key = "source_code"
+
+[sphinx]
+extensions = ["sphinx-jsonschema"]
+
+[sphinx.intersphinx.projects]
+ts-xml = "https://ts-xml.lsst.io"
+salobj = "https://ts-salobj.lsst.io"
+python = "https://docs.python.org/3.13/"

--- a/doc/news/OSW-2112.feature.rst
+++ b/doc/news/OSW-2112.feature.rst
@@ -1,0 +1,1 @@
+Added reconnect retry handling for unexpected controller disconnects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,6 @@ license = { text = "GPL" }
 classifiers = [ "Programming Language :: Python :: 3" ]
 urls = { source_code = "https://github.com/lsst-ts/ts_atbuilding_csc" }
 dynamic = ["version"]
-dependencies = [
-    "ts_tcpip",
-    "ts_salobj",
-    "ts_xml",
-]
 
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }
@@ -35,3 +30,5 @@ __version__ = "{version}"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 
+[project.optional-dependencies]
+dev = ["documenteer[pipelines]"]

--- a/python/lsst/ts/atbuilding/csc/building_csc.py
+++ b/python/lsst/ts/atbuilding/csc/building_csc.py
@@ -39,9 +39,10 @@ MOCK_CTRL_START_TIMEOUT = 2
 # Max time (sec) to wait for a TCP/IP command to complete.
 TCP_TIMEOUT = 1
 
-# Max time (sec) to receive a message from the server.
-# This might be a while if no commands are active.
-SERVER_MESSAGE_TIMEOUT = 30
+# Reconnect behavior (seconds).
+RECONNECT_INITIAL_DELAY = 10.0
+RECONNECT_BACKOFF = 1.5
+RECONNECT_MAX_RETRIES = 10
 
 
 class ATBuildingCsc(salobj.ConfigurableCsc):
@@ -94,6 +95,9 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
 
         # Task that waits for messages from the TCP/IP controller.
         self.listen_task = utils.make_done_future()
+
+        # Task that retries connection on disconnect.
+        self.reconnect_task = utils.make_done_future()
 
         # Set up a dummy tcpip client, to connect to later.
         self.client: tcpip.Client | None = None
@@ -195,6 +199,7 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
             if self.client is None or not self.client.connected:
                 await self.connect()
         else:
+            self._cancel_reconnect()
             await self.disconnect()
 
     async def close_tasks(self) -> None:
@@ -203,8 +208,24 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         """
         await self.disconnect()
 
-    async def connect(self) -> None:
-        """Connect to the building RPi's TCP/IP port."""
+    async def connect(self, allow_fault: bool = True) -> bool:
+        """Connect to the building RPi's TCP/IP port.
+
+        Parameters
+        ----------
+        allow_fault : `bool`
+            If True (the default), transition the CSC to FAULT on a
+            connection failure. Set to False when called from the
+            reconnect loop, which handles the FAULT transition itself
+            only after retries are exhausted.
+
+        Returns
+        -------
+        connected : `bool`
+            True if the connection succeeded (or was already open),
+            False if the attempt failed. When False and ``allow_fault``
+            is True, the CSC has also been driven to FAULT.
+        """
         if self.simulation_mode == 0:
             host = self.config.host
             port = self.config.port
@@ -217,7 +238,7 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         if self.config is None:
             raise RuntimeError("Not yet configured")
         if self.client is not None and self.client.connected:
-            raise RuntimeError("Already connected")
+            return True
 
         self.log.debug(f"Connecting to host={host}, port={port}")
         try:
@@ -235,11 +256,16 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
             )
             self.log.debug("Emitted maximumDriveFrequency event")
 
+            self._cancel_reconnect()
+            return True
         except Exception as e:
             err_msg = f"Could not open connection to host={host}, port={port}: {e!r}"
             self.log.exception(err_msg)
-            await self.fault(code=ErrorCode.TCPIP_CONNECT_ERROR, report=err_msg)
-            return
+            if self.client is not None:
+                await self.client.close()
+            if allow_fault:
+                await self.fault(code=ErrorCode.TCPIP_CONNECT_ERROR, report=err_msg)
+            return False
 
     async def disconnect(self) -> None:
         """Disconnect from the TCP/IP controller, if connected, and stop
@@ -247,9 +273,8 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         """
         self.log.debug("disconnect")
 
-        if self.client is not None:
-            await self.client.close()
-        self.listen_task.cancel()
+        self._cancel_reconnect()
+        await self._close_client()
         await self.stop_mock_ctrl()
         self.log.debug("disconnect done")
 
@@ -334,10 +359,7 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         """
         assert self.client is not None
         if not self.client.connected:
-            await self.fault(
-                code=ErrorCode.UNEXPECTED_DISCONNECT,
-                report="Cannot send a command when not connected.",
-            )
+            self._start_reconnect("Command issued while disconnected.")
             raise RuntimeError("Cannot send a command when not connected.")
         await asyncio.wait_for(self.client.write_str(command), timeout=TCP_TIMEOUT)
 
@@ -367,11 +389,14 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
         called that command.
         """
         assert self.client is not None
-        while self.client.connected:
+        disconnect_reason = "Controller disconnected unexpectedly"
+        while self.client is not None and self.client.connected:
             try:
                 # Receive a message and format it as JSON.
                 self.listen_task = asyncio.create_task(self.client.read_str())
-                message = await self.listen_task
+                message = await asyncio.wait_for(
+                    self.listen_task, timeout=self.config.read_timeout
+                )
 
                 message = message.strip()
                 message_json = json.loads(message)
@@ -385,20 +410,133 @@ class ATBuildingCsc(salobj.ConfigurableCsc):
                     # Response queues provide the response back to the
                     # command that sent them.
                     await self.response_queue[command].put(message_json)
+            except asyncio.TimeoutError:
+                self.log.warning(
+                    "Timed out waiting for controller message after %.1f sec.",
+                    self.config.read_timeout,
+                )
+                disconnect_reason = "Timed out waiting for controller message"
+                self.listen_task.cancel()
+                break
             except asyncio.IncompleteReadError:
                 # Incomplete read implies disconnect
-                break
-            except asyncio.CancelledError:
-                # Cancelled listen_task for disconnect
                 break
             except Exception:
                 self.log.exception("Exception while handling server response.")
 
         if self.disabled_or_enabled:
-            await self.fault(
-                code=ErrorCode.UNEXPECTED_DISCONNECT,
-                report="Controller disconnected unexpectedly",
+            self._start_reconnect(disconnect_reason)
+
+    async def _close_client(self) -> None:
+        """Close the TCP client and cancel the active read task.
+
+        Sets ``self.client`` to None *before* awaiting the close, so any
+        concurrent coroutine checking the attribute sees the disconnected
+        state immediately rather than racing against the close.
+        """
+        client = self.client
+        self.client = None
+        if client is not None:
+            await client.close()
+        self.listen_task.cancel()
+
+    def _cancel_reconnect(self) -> None:
+        """Cancel the running reconnect task, if any.
+
+        Has no effect if no reconnect is in progress, or if the caller
+        is itself the reconnect task (which would otherwise cancel
+        itself mid-execution).
+        """
+        current_task = asyncio.current_task()
+        if not self.reconnect_task.done() and self.reconnect_task is not current_task:
+            self.reconnect_task.cancel()
+
+    def _start_reconnect(
+        self, reason: str, fault_code: ErrorCode = ErrorCode.UNEXPECTED_DISCONNECT
+    ) -> None:
+        """Schedule a background reconnect loop.
+
+        Does nothing if the CSC is not in the DISABLED or ENABLED state,
+        or if a reconnect task is already running. The CSC will be driven
+        to FAULT with ``fault_code`` only if every retry in
+        ``_reconnect_loop`` fails.
+
+        Parameters
+        ----------
+        reason : `str`
+            Human-readable description of why the reconnect was triggered.
+            Logged on each attempt and included in the final FAULT report.
+        fault_code : `ErrorCode`
+            Error code to report if all retries are exhausted. Defaults
+            to ``ErrorCode.UNEXPECTED_DISCONNECT``.
+        """
+        if not self.disabled_or_enabled:
+            self.log.info("Not reconnecting in summary state %s", self.summary_state)
+            return
+        if not self.reconnect_task.done():
+            return
+        self.log.warning("Starting reconnect loop: %s", reason)
+        self.reconnect_task = asyncio.create_task(
+            self._reconnect_loop(reason, fault_code)
+        )
+
+    async def _reconnect_loop(self, reason: str, fault_code: ErrorCode) -> None:
+        """Retry the controller connection with exponential backoff.
+
+        Closes any existing client (and mock controller, in simulation
+        mode), then makes up to ``RECONNECT_MAX_RETRIES`` attempts,
+        sleeping ``RECONNECT_INITIAL_DELAY`` seconds before the first
+        attempt and multiplying the delay by ``RECONNECT_BACKOFF``
+        after each failure. Returns early if the CSC leaves the
+        DISABLED/ENABLED states, if the client becomes connected
+        by other means, or if the task is cancelled. If every attempt
+        fails, drives the CSC to FAULT with ``fault_code``.
+
+        Parameters
+        ----------
+        reason : `str`
+            Human-readable cause of the disconnect, propagated to log
+            messages and the FAULT report.
+        fault_code : `ErrorCode`
+            Error code to use if retries are exhausted.
+        """
+        await self._close_client()
+        if self.simulation_mode == 1:
+            await self.stop_mock_ctrl()
+        delay = RECONNECT_INITIAL_DELAY
+        for attempt in range(1, RECONNECT_MAX_RETRIES + 1):
+            if self.client is not None and self.client.connected:
+                return
+            self.log.warning(
+                "Reconnect attempt %d/%d in %.1f sec (%s).",
+                attempt,
+                RECONNECT_MAX_RETRIES,
+                delay,
+                reason,
             )
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+
+            if not self.disabled_or_enabled:
+                self.log.info(
+                    "Reconnect loop canceled due to summary state %s",
+                    self.summary_state,
+                )
+                return
+
+            if await self.connect(allow_fault=False):
+                self.log.info("Reconnect succeeded.")
+                return
+            delay *= RECONNECT_BACKOFF
+
+        await self.fault(
+            code=fault_code,
+            report=(
+                f"Reconnect failed after {RECONNECT_MAX_RETRIES} attempts: {reason}"
+            ),
+        )
 
 
 def run_atbuilding() -> None:

--- a/tests/test_atbuilding_csc.py
+++ b/tests/test_atbuilding_csc.py
@@ -20,9 +20,11 @@
 
 import asyncio
 import unittest
+from unittest.mock import patch
 
 from lsst.ts import salobj
 from lsst.ts.atbuilding import csc
+from lsst.ts.atbuilding.csc import building_csc
 from lsst.ts.atbuilding.csc.enums import ErrorCode
 from lsst.ts.xml.enums.ATBuilding import FanDriveState, VentGateState
 
@@ -252,8 +254,8 @@ class ATBuildingTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.remote.cmd_enable.start()
             await self.assert_next_summary_state(salobj.State.ENABLED)
 
-    async def test_unexpected_disconnect_faults(self) -> None:
-        """Test that an unexpected disconnect drives the CSC to FAULT."""
+    async def test_unexpected_disconnect_reconnects(self) -> None:
+        """Test that an unexpected disconnect reconnects successfully."""
         async with self.make_csc(
             initial_state=salobj.State.ENABLED, config_dir=None, simulation_mode=1
         ):
@@ -264,14 +266,63 @@ class ATBuildingTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             self.remote.evt_errorCode.flush()
             self.remote.evt_summaryState.flush()
 
-            await self.csc.mock_ctrl.close()
+            with (
+                patch.object(building_csc, "RECONNECT_INITIAL_DELAY", 0.01),
+                patch.object(building_csc, "RECONNECT_BACKOFF", 1.0),
+                patch.object(building_csc, "RECONNECT_MAX_RETRIES", 2),
+            ):
+                original_reconnect_task = self.csc.reconnect_task
+                await self.csc.mock_ctrl.close()
 
-            await self.assert_next_summary_state(salobj.State.FAULT)
-            await self.assert_next_sample(
-                topic=self.remote.evt_errorCode,
-                errorCode=int(ErrorCode.UNEXPECTED_DISCONNECT),
-                flush=False,
-            )
+                with self.assertRaises(salobj.AckError):
+                    await self.remote.cmd_openVentGate.set_start(gate=[0, -1, -1, -1])
+
+                async def wait_for_reconnect_start() -> None:
+                    while self.csc.reconnect_task is original_reconnect_task:
+                        await asyncio.sleep(0.05)
+
+                await asyncio.wait_for(wait_for_reconnect_start(), timeout=5)
+                await asyncio.wait_for(
+                    asyncio.shield(self.csc.reconnect_task), timeout=5
+                )
+                await self.remote.cmd_openVentGate.set_start(gate=[0, -1, -1, -1])
+                await self.wait_for_vent_gate_state(
+                    [VentGateState.OPENED] + [VentGateState.CLOSED] * 3
+                )
+
+    async def test_unexpected_disconnect_faults_after_retries(self) -> None:
+        """Test that reconnect retries exhaust to UNEXPECTED_DISCONNECT."""
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED, config_dir=None, simulation_mode=1
+        ):
+            assert self.csc.mock_ctrl is not None
+            await self.csc.start_mock_ctrl()
+
+            await asyncio.sleep(1)
+            self.remote.evt_errorCode.flush()
+            self.remote.evt_summaryState.flush()
+
+            connect_attempts = 0
+
+            async def fake_connect(allow_fault: bool = True) -> bool:
+                nonlocal connect_attempts
+                connect_attempts += 1
+                return False
+
+            with (
+                patch.object(building_csc, "RECONNECT_INITIAL_DELAY", 0.01),
+                patch.object(building_csc, "RECONNECT_BACKOFF", 1.0),
+                patch.object(self.csc, "connect", fake_connect),
+            ):
+                await self.csc.mock_ctrl.close()
+
+                await self.assert_next_summary_state(salobj.State.FAULT)
+                await self.assert_next_sample(
+                    topic=self.remote.evt_errorCode,
+                    errorCode=int(ErrorCode.UNEXPECTED_DISCONNECT),
+                    flush=False,
+                )
+                self.assertEqual(connect_attempts, building_csc.RECONNECT_MAX_RETRIES)
 
 
 if __name__ == "__main__":

--- a/ups/ts_atbuilding_csc.table
+++ b/ups/ts_atbuilding_csc.table
@@ -7,6 +7,10 @@ setupRequired(sconsUtils)
 # ts_atbuilding_vents required for `cast_string_to_type` function.
 setupRequired(ts_vent_controller)
 
+setupRequired(ts_salobj)
+setupRequired(ts_tcpip)
+
+
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Previously, any unexpected disconnect from the dome vent controller drove the CSC straight to FAULT, requiring operator intervention even for transient blips (controller restart, brief network hiccup). This PR replaces the immediate-fault behavior with a background reconnect loop that retries with exponential backoff before falling back to FAULT.

Key changes are as follows:

- **New reconnect loop.** On unexpected disconnect, `_start_reconnect` schedules a background task that retries `connect()` up to `RECONNECT_MAX_RETRIES` (10) times, starting at `RECONNECT_INITIAL_DELAY` (10s) and multiplying by `RECONNECT_BACKOFF` (1.5) after each failure. The CSC only transitions to FAULT if every attempt fails.
- **Read timeout on the listen task.** `listen_for_messages` now wraps each read in `asyncio.wait_for(..., timeout=self.config.read_timeout)`, so a wedged-but-still-open socket triggers the reconnect path instead of blocking indefinitely.
- **Race-safe teardown.** New `_close_client` helper nulls `self.client` *before* awaiting the close, so concurrent coroutines see the disconnected state immediately. `disconnect()` and state transitions out of DISABLED/ENABLED cancel any in-flight reconnect.
- **Command path change.** `run_command` now kicks off a reconnect on a disconnected client (instead of FAULTing) before raising `RuntimeError` to the caller.
- New tests `test_unexpected_disconnect_reconnects` and `test_unexpected_disconnect_faults_after_retries`